### PR TITLE
WIP: Format json

### DIFF
--- a/lib/diff.go
+++ b/lib/diff.go
@@ -6,9 +6,9 @@ import (
 )
 
 type DiffElement struct {
-	Path      Path
-	OldValues []JsonNode
-	NewValues []JsonNode
+	Path      Path       `json:"path"`
+	OldValues []JsonNode `json:"old"`
+	NewValues []JsonNode `json:"new"`
 }
 
 func (d DiffElement) Render() string {

--- a/main.go
+++ b/main.go
@@ -110,10 +110,12 @@ func patchJson(p, a string) {
 	var err error
 	var diff jd.Diff
 	switch *format {
+	case "json":
+		err = json.Unmarshal([]byte(p), &diff)
 	case "native":
 		diff, err = readDiffString(p)
 	default:
-		err = errors.New("Supported formats are json (TODO) or native")
+		err = errors.New("Supported formats are json or native")
 	}
 	if err != nil {
 		log.Fatalf(err.Error())


### PR DESCRIPTION
These commits add a `-f` flag to specify the format for the patch. The current format is named `native` and JSON is supported using `-f=json`.

While encoding patches works, decoding them does not work yet.

Here is the error, I'm getting:

```
json: cannot unmarshal string into Go struct field DiffElement.old of type jd.JsonNode
```

With this patch:

```
[{"path":["foo"],"old":["bar"],"new":["baz"]}]
```

Potentially we could tell the unmarshaller to call `NewJsonNode`.