### PR TITLE
Fixes json patch apply code

### DIFF
--- a/lib/e2e_test.go
+++ b/lib/e2e_test.go
@@ -22,6 +22,14 @@ func TestDiffAndPatch(t *testing.T) {
 		`[{"a":2},{"a":3,"b":4},{"c":5}]`)
 }
 
+func TestDiffAndPatchSet(t *testing.T) {
+	checkDiffAndPatchSuccessSet(t,
+		`{"a":{"b" : ["3", "4" ],"c" : ["2", "1"]}}`,
+		`{"a":{"b" : ["3", "4", "5", "6"],"c" : ["2", "1"]}}`,
+		`{"a":{"b" : ["3", "4" ],"c" : ["2", "1"]}}`,
+		`{"a":{"b" : ["3", "4", "5", "6"],"c" : ["2", "1"]}}`)
+}
+
 func TestDiffAndPatchError(t *testing.T) {
 	checkDiffAndPatchError(t,
 		`{"a":1}`,
@@ -41,6 +49,13 @@ func TestDiffAndPatchError(t *testing.T) {
 		`2`)
 }
 
+func checkDiffAndPatchSuccessSet(t *testing.T, a, b, c, expect string) {
+	err := checkDiffAndPatch(t, a, b, c, expect, SET)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+}
+
 func checkDiffAndPatchSuccess(t *testing.T, a, b, c, expect string) {
 	err := checkDiffAndPatch(t, a, b, c, expect)
 	if err != nil {
@@ -55,25 +70,25 @@ func checkDiffAndPatchError(t *testing.T, a, b, c string) {
 	}
 }
 
-func checkDiffAndPatch(t *testing.T, a, b, c, expect string) error {
-	nodeA, err := ReadJsonString(a)
+func checkDiffAndPatch(t *testing.T, a, b, c, expect string, options ...option) error {
+	nodeA, err := ReadJsonString(a, options...)
 	if err != nil {
 		return err
 	}
-	nodeB, err := ReadJsonString(b)
+	nodeB, err := ReadJsonString(b, options...)
 	if err != nil {
 		return err
 	}
-	nodeC, err := ReadJsonString(c)
+	nodeC, err := ReadJsonString(c, options...)
 	if err != nil {
 		return err
 	}
-	expectNode, err := ReadJsonString(expect)
+	expectNode, err := ReadJsonString(expect, options...)
 	if err != nil {
 		return err
 	}
 	diffString := nodeA.Diff(nodeB).Render()
-	diff, err := ReadDiffString(diffString)
+	diff, err := ReadDiffString(diffString, options...)
 	if err != nil {
 		return err
 	}

--- a/lib/input.go
+++ b/lib/input.go
@@ -159,11 +159,6 @@ func readDiff(s string, options ...option) (Diff, error) {
 func checkDiffElement(de DiffElement) string {
 	if len(de.NewValues) > 1 || len(de.OldValues) > 1 {
 		// Must be a set.
-		if len(de.Path) == 0 {
-			//print("Empty path\n")
-		} else {
-			//print(de.Path[0])
-		}
 		if len(de.Path) == 0 || !reflect.DeepEqual(de.Path[len(de.Path)-1], map[string]interface{}{}) {
 			return "Expected path to end with {} for sets."
 		}

--- a/lib/input.go
+++ b/lib/input.go
@@ -111,6 +111,7 @@ func readDiff(s string, options ...option) (Diff, error) {
 				diff = append(diff, de)
 			}
 			p := Path{}
+			//print(dl[1:], "\n")
 			err := json.Unmarshal([]byte(dl[1:]), &p)
 			if err != nil {
 				return errorAt(i, "Invalid path. %v", err.Error())
@@ -158,7 +159,12 @@ func readDiff(s string, options ...option) (Diff, error) {
 func checkDiffElement(de DiffElement) string {
 	if len(de.NewValues) > 1 || len(de.OldValues) > 1 {
 		// Must be a set.
-		if len(de.Path) == 0 || !reflect.DeepEqual(de.Path[0], map[string]interface{}{}) {
+		if len(de.Path) == 0 {
+			//print("Empty path\n")
+		} else {
+			//print(de.Path[0])
+		}
+		if len(de.Path) == 0 || !reflect.DeepEqual(de.Path[len(de.Path)-1], map[string]interface{}{}) {
 			return "Expected path to end with {} for sets."
 		}
 	}

--- a/lib/input.go
+++ b/lib/input.go
@@ -111,7 +111,6 @@ func readDiff(s string, options ...option) (Diff, error) {
 				diff = append(diff, de)
 			}
 			p := Path{}
-			//print(dl[1:], "\n")
 			err := json.Unmarshal([]byte(dl[1:]), &p)
 			if err != nil {
 				return errorAt(i, "Invalid path. %v", err.Error())

--- a/lib/object.go
+++ b/lib/object.go
@@ -2,7 +2,6 @@ package jd
 
 import (
 	"fmt"
-	"reflect"
 	"sort"
 )
 
@@ -22,7 +21,18 @@ func (o1 jsonObject) Equals(n JsonNode) bool {
 	if len(o1) != len(o2) {
 		return false
 	}
-	return reflect.DeepEqual(o1, o2)
+
+	for key1, val1 := range o1 {
+		val2, ok := o2[key1]
+		if !ok {
+			return false
+		}
+		ret := val1.Equals(val2)
+		if !ret {
+			return false
+		}
+	}
+	return true
 }
 
 func (o jsonObject) hashCode() [8]byte {
@@ -103,13 +113,13 @@ func (o jsonObject) Patch(d Diff) (JsonNode, error) {
 }
 
 func (o jsonObject) patch(pathBehind, pathAhead Path, oldValues, newValues []JsonNode) (JsonNode, error) {
-	if len(oldValues) > 1 || len(newValues) > 1 {
+	if (len(pathAhead) == 0) && (len(oldValues) > 1 || len(newValues) > 1) {
 		return patchErrNonSetDiff(oldValues, newValues, pathBehind)
 	}
-	oldValue := singleValue(oldValues)
-	newValue := singleValue(newValues)
 	// Base case
 	if len(pathAhead) == 0 {
+		oldValue := singleValue(oldValues)
+		newValue := singleValue(newValues)
 		if !o.Equals(oldValue) {
 			return patchErrExpectValue(oldValue, o, pathBehind)
 		}


### PR DESCRIPTION
Patch command fails to apply patch to json if:- 
1. Patch is created using set mode. (jd -set)
2. the json consists of nested maps
3.  Between jsons multiple elements are added to array in a nested element.
E.g. 
File1 :-
{
	"a": {
		"b": ["1", "2"],
		"c": ["3", "4"]
	}
}

file2:-
Aftab-MacBook:jsodiffTest aftab.ansari$ cat file4
{
	"a": {
		"b" : ["2", "1"],
		"c" : ["3", "4", "5", "6"]
	}
}

Generated patch is as :-
@ ["a","c",{}]
+ "5"
+ "6"

Fix involved fixing few of the checks done while patch is executed. Also added updated e2e test case to test the same. All tests are passing.