### PR TITLE
Null becomes empty object

### DIFF
--- a/lib/array_test.go
+++ b/lib/array_test.go
@@ -47,7 +47,7 @@ func TestArrayDiff(t *testing.T) {
 		`@ [0]`,
 		`- 1`)
 	checkDiff(ctx, `[[]]`, `[[1]]`,
-		`@ [0, 0]`,
+		`@ [0,0]`,
 		`+ 1`)
 	checkDiff(ctx, `[1]`, `[2]`,
 		`@ [0]`,

--- a/lib/common_test.go
+++ b/lib/common_test.go
@@ -90,14 +90,9 @@ func checkDiff(ctx *testContext, a, b string, diffLines ...string) {
 		diff += dl + "\n"
 	}
 	d := nodeA.Diff(nodeB, ctx.metadata...)
-	expectedDiff, err := ReadDiffString(diff)
-	if err != nil {
-		ctx.t.Fatalf(err.Error())
-	}
-	want := expectedDiff.Render()
 	got := d.Render()
-	if got != want {
-		ctx.t.Errorf("%v.Diff(%v) = \n%v. Want %v.", nodeA, nodeB, got, want)
+	if got != diff {
+		ctx.t.Errorf("%v.Diff(%v) = \n%v. Want %v.", nodeA, nodeB, got, diff)
 	}
 }
 

--- a/lib/multiset_test.go
+++ b/lib/multiset_test.go
@@ -143,7 +143,7 @@ func TestMultisetDiff(t *testing.T) {
 		metadata: MULTISET,
 		a:        `[]`,
 		b:        `[]`,
-		want:     s(``),
+		want:     s(),
 	}, {
 		name:     "two multisets with different numbers",
 		metadata: MULTISET,
@@ -158,7 +158,7 @@ func TestMultisetDiff(t *testing.T) {
 		metadata: MULTISET,
 		a:        `[1,2]`,
 		b:        `[1,2]`,
-		want:     s(``),
+		want:     s(),
 	}, {
 		name:     "adding two numbers",
 		metadata: MULTISET,

--- a/lib/node.go
+++ b/lib/node.go
@@ -52,7 +52,7 @@ func NewJsonNode(n interface{}) (JsonNode, error) {
 	case bool:
 		return jsonBool(t), nil
 	case nil:
-		return jsonNull{}, nil
+		return jsonNull(nil), nil
 	default:
 		return nil, errors.New(fmt.Sprintf("Unsupported type %v", t))
 	}

--- a/lib/null.go
+++ b/lib/null.go
@@ -1,11 +1,11 @@
 package jd
 
-type jsonNull struct{}
+type jsonNull []byte
 
 var _ JsonNode = jsonNull{}
 
 func (n jsonNull) Json(metadata ...Metadata) string {
-	return renderJson(nil)
+	return renderJson(n)
 }
 
 func (n jsonNull) Equals(node JsonNode, metadata ...Metadata) bool {

--- a/lib/set_test.go
+++ b/lib/set_test.go
@@ -157,7 +157,7 @@ func TestSetDiff(t *testing.T) {
 		metadata: m(SET),
 		a:        `[]`,
 		b:        `[]`,
-		want:     s(``),
+		want:     s(),
 	}, {
 		name:     "add a number",
 		metadata: m(SET),
@@ -172,7 +172,7 @@ func TestSetDiff(t *testing.T) {
 		metadata: m(SET),
 		a:        `[1,2]`,
 		b:        `[1,2]`,
-		want:     s(``),
+		want:     s(),
 	}, {
 		name:     "add a number multiple times",
 		metadata: m(SET),
@@ -309,7 +309,7 @@ func TestSetDiff(t *testing.T) {
 		metadata: m(SET),
 		a:        `{"a":[1,2]}`,
 		b:        `{"a":[2,1]}`,
-		want:     s(``),
+		want:     s(),
 	}}
 
 	for _, c := range cases {


### PR DESCRIPTION
See https://github.com/josephburnett/jd/issues/20
---
Fixes bug in test helper to expose 5 failing tests
```
$ go test
--- FAIL: TestArrayDiff (0.00s)
    common_test.go:120: [1 2 3].Diff([1 {} 3]) =
        @ [1]
        - 2
        + {}
        . Want @ [1]
        - 2
        + null
        .
--- FAIL: TestNullDiff (0.00s)
    common_test.go:120: {}.Diff({}) =
        @ []
        - {}
        . Want @ []
        - null
        .
    common_test.go:120: {}.Diff({}) =
        @ []
        + {}
        . Want @ []
        + null
        .
--- FAIL: TestObjectDiff (0.00s)
    common_test.go:120: {map[a:1] map[]}.Diff({map[a:{}] map[]}) =
        @ ["a"]
        - 1
        + {}
        . Want @ ["a"]
        - 1
        + null
        .
--- FAIL: TestStringDiff (0.00s)
    common_test.go:120: {}.Diff(abc) =
        @ []
        - {}
        + "abc"
        . Want @ []
        - null
        + "abc"
        .
FAIL
exit status 1
FAIL    github.com/josephburnett/jd/lib 0.026s
```
Changes jsonNull into a type that marshals cleanly to `null`
```diff
-type jsonNull struct{}
+type jsonNull []byte
```