### PR TITLE
Convert array tests to TableDrivenTests

### DIFF
--- a/lib/array_test.go
+++ b/lib/array_test.go
@@ -17,8 +17,8 @@ func TestArrayJson(t *testing.T) {
 		{ctx, ` [1, 2, 3] `, `[1,2,3]`},
 	}
 
-	for _, test := range tests {
-		checkJson(test.context, test.a, test.b)
+	for _, tt := range tests {
+		checkJson(tt.context, tt.a, tt.b)
 	}
 }
 
@@ -36,8 +36,8 @@ func TestArrayEqual(t *testing.T) {
 		{ctx, `[{"a":[]}]`, `[{"a":[]}]`},
 	}
 
-	for _, test := range tests {
-		checkEqual(test.context, test.a, test.b)
+	for _, tt := range tests {
+		checkEqual(tt.context, tt.a, tt.b)
 	}
 }
 
@@ -54,8 +54,8 @@ func TestArrayNotEqual(t *testing.T) {
 		{ctx, `[1,2,3]`, `[3,2,1]`},
 	}
 
-	for _, test := range tests {
-		checkNotEqual(test.context, test.a, test.b)
+	for _, tt := range tests {
+		checkNotEqual(tt.context, tt.a, tt.b)
 	}
 }
 
@@ -75,8 +75,8 @@ func TestArrayHash(t *testing.T) {
 		{ctx, `[[1]]`, `[[[1]]]`, false},
 	}
 
-	for _, test := range tests {
-		checkHash(test.context, test.a, test.b, test.wantSame)
+	for _, tt := range tests {
+		checkHash(tt.context, tt.a, tt.b, tt.wantSame)
 	}
 }
 
@@ -150,8 +150,8 @@ func TestArrayDiff(t *testing.T) {
 	    },
 	}
 
-	for _, test := range tests {
-		checkDiff(test.context, test.a, test.b, test.diffLines...)
+	for _, tt := range tests {
+		checkDiff(tt.context, tt.a, tt.b, tt.diffLines...)
 	}
 }
 
@@ -238,8 +238,8 @@ func TestArrayPatch(t *testing.T) {
 		
 	}
 
-	for _, test := range tests {
-		checkPatch(test.context, test.a, test.b, test.diffLines...)
+	for _, tt := range tests {
+		checkPatch(tt.context, tt.a, tt.b, tt.diffLines...)
 	}
 }
 
@@ -282,7 +282,7 @@ func TestArrayPatchError(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		checkPatchError(test.context, test.a, test.diffLines...)
+	for _, tt := range tests {
+		checkPatchError(tt.context, tt.a, tt.diffLines...)
 	}
 }

--- a/lib/array_test.go
+++ b/lib/array_test.go
@@ -4,148 +4,285 @@ import (
 	"testing"
 )
 
-// TODO: convert array tests to table tests.
 func TestArrayJson(t *testing.T) {
 	ctx := newTestContext(t)
-	checkJson(ctx, `[]`, `[]`)
-	checkJson(ctx, ` [ ] `, `[]`)
-	checkJson(ctx, `[1,2,3]`, `[1,2,3]`)
-	checkJson(ctx, ` [1, 2, 3] `, `[1,2,3]`)
+	tests := []struct {
+		context *testContext
+		a           string
+		b           string
+	}{
+		{ctx, `[]`, `[]`},
+		{ctx, ` [ ] `, `[]`},
+		{ctx, `[1,2,3]`, `[1,2,3]`},
+		{ctx, ` [1, 2, 3] `, `[1,2,3]`},
+	}
+
+	for _, test := range tests {
+		checkJson(test.context, test.a, test.b)
+	}
 }
 
 func TestArrayEqual(t *testing.T) {
 	ctx := newTestContext(t)
-	checkEqual(ctx, `[]`, `[]`)
-	checkEqual(ctx, `[1,2,3]`, `[1,2,3]`)
-	checkEqual(ctx, `[[]]`, `[[]]`)
-	checkEqual(ctx, `[{"a":1}]`, `[{"a":1}]`)
-	checkEqual(ctx, `[{"a":[]}]`, `[{"a":[]}]`)
+	tests := []struct {
+		context *testContext
+		a       string
+		b       string
+	}{
+		{ctx, `[]`, `[]`},
+		{ctx, `[1,2,3]`, `[1,2,3]`},
+		{ctx, `[[]]`, `[[]]`},
+		{ctx, `[{"a":1}]`, `[{"a":1}]`},
+		{ctx, `[{"a":[]}]`, `[{"a":[]}]`},
+	}
+
+	for _, test := range tests {
+		checkEqual(test.context, test.a, test.b)
+	}
 }
 
 func TestArrayNotEqual(t *testing.T) {
 	ctx := newTestContext(t)
-	checkNotEqual(ctx, `[]`, `0`)
-	checkNotEqual(ctx, `[]`, `{}`)
-	checkNotEqual(ctx, `[]`, `[[]]`)
-	checkNotEqual(ctx, `[1,2,3]`, `[3,2,1]`)
+	tests := []struct {
+		context *testContext
+		a       string
+		b       string
+	}{
+		{ctx, `[]`, `0`},
+		{ctx, `[]`, `{}`},
+		{ctx, `[]`, `[[]]`},
+		{ctx, `[1,2,3]`, `[3,2,1]`},
+	}
+
+	for _, test := range tests {
+		checkNotEqual(test.context, test.a, test.b)
+	}
 }
 
 func TestArrayHash(t *testing.T) {
 	ctx := newTestContext(t)
-	checkHash(ctx, `[]`, `[]`, true)
-	checkHash(ctx, `[1]`, `[]`, false)
-	checkHash(ctx, `[1]`, `[1]`, true)
-	checkHash(ctx, `[1]`, `[2]`, false)
-	checkHash(ctx, `[[1]]`, `[[1]]`, true)
-	checkHash(ctx, `[[1]]`, `[[[1]]]`, false)
+	tests := []struct {
+		context  *testContext
+		a        string
+		b        string
+		wantSame bool
+	}{
+		{ctx, `[]`, `[]`, true},
+		{ctx, `[1]`, `[]`, false},
+		{ctx, `[1]`, `[1]`, true},
+		{ctx, `[1]`, `[2]`, false},
+		{ctx, `[[1]]`, `[[1]]`, true},
+		{ctx, `[[1]]`, `[[[1]]]`, false},
+	}
+
+	for _, test := range tests {
+		checkHash(test.context, test.a, test.b, test.wantSame)
+	}
 }
 
 func TestArrayDiff(t *testing.T) {
 	ctx := newTestContext(t)
-	checkDiff(ctx, `[]`, `[]`)
-	checkDiff(ctx, `[1]`, `[]`,
-		`@ [0]`,
-		`- 1`)
-	checkDiff(ctx, `[[]]`, `[[1]]`,
-		`@ [0,0]`,
-		`+ 1`)
-	checkDiff(ctx, `[1]`, `[2]`,
-		`@ [0]`,
-		`- 1`,
-		`+ 2`)
-	checkDiff(ctx, `[]`, `[2]`,
-		`@ [0]`,
-		`+ 2`)
-	checkDiff(ctx, `[[]]`, `[{}]`,
-		`@ [0]`,
-		`- []`,
-		`+ {}`)
-	checkDiff(ctx, `[{"a":[1]}]`, `[{"a":[2]}]`,
-		`@ [0,"a",0]`,
-		`- 1`,
-		`+ 2`)
-	checkDiff(ctx, `[1,2,3]`, `[1,2]`,
-		`@ [2]`,
-		`- 3`)
-	checkDiff(ctx, `[1,2,3]`, `[1,4,3]`,
-		`@ [1]`,
-		`- 2`,
-		`+ 4`)
-	checkDiff(ctx, `[1,2,3]`, `[1,null,3]`,
-		`@ [1]`,
-		`- 2`,
-		`+ null`)
-	checkDiff(ctx, `[]`, `[3,4,5]`,
-		`@ [0]`,
-		`+ 3`,
-		`@ [1]`,
-		`+ 4`,
-		`@ [2]`,
-		`+ 5`)
+	tests := []struct {
+		context   *testContext
+		a         string
+		b         string
+		diffLines []string
+	}{
+		{ctx, `[]`, `[]`, []string {}},
+		{ctx, `[1]`, `[]`, []string {
+			`@ [0]`,
+	        `- 1`,
+		  },
+	    },
+		{ctx, `[[]]`, `[[1]]`, []string {
+			`@ [0,0]`,
+		    `+ 1`,
+		  },
+	    },
+		{ctx, `[1]`, `[2]`, []string {
+			`@ [0]`,
+		    `- 1`,
+		    `+ 2`,
+		  },
+	    },
+		{ctx, `[]`, `[2]`, []string {
+			`@ [0]`,
+		    `+ 2`,
+		  },
+	    },
+		{ctx, `[[]]`, `[{}]`, []string {
+			`@ [0]`,
+		    `- []`,
+		    `+ {}`,
+		  },
+	    },
+		{ctx, `[{"a":[1]}]`, `[{"a":[2]}]`, []string {
+			`@ [0,"a",0]`,
+		    `- 1`,
+		    `+ 2`,
+		  },
+	    },
+		{ctx, `[1,2,3]`, `[1,2]`, []string {
+			`@ [2]`,
+		    `- 3`,
+		  },
+	    },
+		{ctx, `[1,2,3]`, `[1,4,3]`, []string {
+			`@ [1]`,
+		    `- 2`,
+		    `+ 4`,
+		  },
+	    },
+		{ctx, `[1,2,3]`, `[1,null,3]`, []string {
+			`@ [1]`,
+		    `- 2`,
+		    `+ null`,
+		  },
+	    },
+		{ctx, `[]`, `[3,4,5]`, []string {
+			`@ [0]`,
+		    `+ 3`,
+		    `@ [1]`,
+		    `+ 4`,
+		    `@ [2]`,
+		    `+ 5`,
+		  },
+	    },
+	}
+
+	for _, test := range tests {
+		checkDiff(test.context, test.a, test.b, test.diffLines...)
+	}
 }
 
 func TestArrayPatch(t *testing.T) {
 	ctx := newTestContext(t)
-	checkPatch(ctx, `[]`, `[]`)
-	checkPatch(ctx, `[1]`, `[]`,
-		`@ [0]`,
-		`- 1`)
-	checkPatch(ctx, `[[]]`, `[[1]]`,
-		`@ [0, 0]`,
-		`+ 1`)
-	checkPatch(ctx, `[1]`, `[2]`,
-		`@ [0]`,
-		`- 1`,
-		`+ 2`)
-	checkPatch(ctx, `[]`, `[2]`,
-		`@ [0]`,
-		`+ 2`)
-	checkPatch(ctx, `[[]]`, `[{}]`,
-		`@ [0]`,
-		`- []`,
-		`+ {}`)
-	checkPatch(ctx, `[{"a":[1]}]`, `[{"a":[2]}]`,
-		`@ [0,"a",0]`,
-		`- 1`,
-		`+ 2`)
-	checkPatch(ctx, `[1,2,3]`, `[1,2]`,
-		`@ [2]`,
-		`- 3`)
-	checkPatch(ctx, `[1,2,3]`, `[1,4,3]`,
-		`@ [1]`,
-		`- 2`,
-		`+ 4`)
-	checkPatch(ctx, `[1,2,3]`, `[1,null,3]`,
-		`@ [1]`,
-		`- 2`,
-		`+ null`)
-	checkPatch(ctx, "[]", "[3,4,5]",
-		"@ [0]",
-		"+ 3",
-		"@ [1]",
-		"+ 4",
-		"@ [2]",
-		"+ 5")
+	tests := []struct {
+		context   *testContext
+		a         string
+		b         string
+		diffLines []string
+	}{
+		{ctx, `[]`, `[]`, []string {}},
+		{ctx, `[1]`, `[]`, []string {
+			`@ [0]`,
+	        `- 1`,
+		  },
+	    },
+		{ctx, `[[]]`, `[[1]]`, []string {
+			`@ [0, 0]`,
+			`+ 1`,
+		  },
+	    },
+		{ctx, `[1]`, `[2]`, []string {
+			`@ [0]`,
+			`- 1`,
+			`+ 2`,
+		  },
+	    },
+		{ctx, `[1]`, `[2]`, []string {
+			`@ [0]`,
+			`- 1`,
+			`+ 2`,
+		  },
+	    },
+		{ctx, `[]`, `[2]`, []string {
+			`@ [0]`,
+		    `+ 2`,
+		  },
+	    },
+		{ctx, `[[]]`, `[{}]`, []string {
+			`@ [0]`,
+		    `- []`,
+		    `+ {}`,
+		  },
+	    },
+		{ctx, `[{"a":[1]}]`, `[{"a":[2]}]`, []string {
+			`@ [0,"a",0]`,
+		    `- 1`,
+		    `+ 2`,
+		  },
+	    },
+		{ctx, `[1,2,3]`, `[1,2]`, []string {
+			`@ [2]`,
+		    `- 3`,
+		  },
+	    },
+		{ctx, `[1,2,3]`, `[1,4,3]`, []string {
+			`@ [1]`,
+		    `- 2`,
+		    `+ 4`,
+		  },
+	    },
+		{ctx, `[1,2,3]`, `[1,null,3]`, []string {
+			`@ [1]`,
+		    `- 2`,
+		    `+ null`,
+		  },
+	    },
+		{ctx, `[1,2,3]`, `[1,null,3]`, []string {
+			`@ [1]`,
+		    `- 2`,
+		    `+ null`,
+		  },
+	    },
+		{ctx, "[]", "[3,4,5]", []string {
+			"@ [0]",
+		    "+ 3",
+		    "@ [1]",
+		    "+ 4",
+		    "@ [2]",
+		    "+ 5",
+		  },
+	    },
+		
+	}
+
+	for _, test := range tests {
+		checkPatch(test.context, test.a, test.b, test.diffLines...)
+	}
 }
 
 func TestArrayPatchError(t *testing.T) {
 	ctx := newTestContext(t)
-	checkPatchError(ctx, `[]`,
-		`@ ["a"]`,
-		`+ 1`)
-	checkPatchError(ctx, `[]`,
-		`@ [0]`,
-		`- 1`)
-	checkPatchError(ctx, `[]`,
-		`@ [0]`,
-		`- null`)
-	checkPatchError(ctx, `[1,2,3]`,
-		`@ [1]`,
-		`- 2`)
-	checkPatchError(ctx, `[1,2,3]`,
-		`@ [0]`,
-		`- 1`)
-	checkPatchError(ctx, `[1,3]`,
-		`@ [1]`,
-		`+ 2`)
+	tests := []struct {
+		context   *testContext
+		a         string
+		diffLines []string
+	}{
+		{ctx, `[]`, []string {
+			`@ ["a"]`,
+		    `+ 1`,
+		  },
+		},
+		{ctx, `[]`, []string {
+			`@ [0]`,
+		    `- 1`,
+		  },
+		},
+		{ctx, `[]`, []string {
+			`@ [0]`,
+		    `- null`,
+		  },
+		},
+		{ctx, `[1,2,3]`, []string {
+			`@ [1]`,
+		    `- 2`,
+		  },
+		},
+		{ctx, `[1,2,3]`, []string {
+			`@ [0]`,
+		    `- 1`,
+		  },
+		},
+		{ctx, `[1,3]`, []string {
+			`@ [1]`,
+		    `+ 2`,
+		  },
+		},
+	}
+
+	for _, test := range tests {
+		checkPatchError(test.context, test.a, test.diffLines...)
+	}
 }


### PR DESCRIPTION
Hi :)
I done this `TODO` .
https://github.com/josephburnett/jd/blob/d1d4edfee5375f88c1155ef55158597fb8488751/lib/array_test.go#L7

Ref: https://github.com/golang/go/wiki/TableDrivenTests

### Result

```zsh
~/go/src/jd/lib
$ go test -v -cover
=== RUN   TestArrayJson
--- PASS: TestArrayJson (0.00s)
=== RUN   TestArrayEqual
--- PASS: TestArrayEqual (0.00s)
=== RUN   TestArrayNotEqual
--- PASS: TestArrayNotEqual (0.00s)
=== RUN   TestArrayHash
--- PASS: TestArrayHash (0.00s)
=== RUN   TestArrayDiff
--- PASS: TestArrayDiff (0.00s)
=== RUN   TestArrayPatch
--- PASS: TestArrayPatch (0.00s)
...
...
PASS
coverage: 85.9% of statements
```