### PR TITLE
Explicitly return exit codes when differences are found.

### DIFF
--- a/main.go
+++ b/main.go
@@ -147,9 +147,19 @@ func printDiff(a, b string, metadata []jd.Metadata) {
 	}
 	diff := aNode.Diff(bNode, metadata...)
 	if *output == "" {
-		fmt.Print(diff.Render())
+		str := diff.Render()
+		if  str == "" {
+			os.Exit(0)
+		}
+		fmt.Print(str)
+		os.Exit(1)
 	} else {
-		ioutil.WriteFile(*output, []byte(diff.Render()), 0644)
+		str := diff.Render()
+		if str == "" {
+			os.Exit(0)
+		}
+		ioutil.WriteFile(*output, []byte(str), 0644)
+		os.Exit(1)
 	}
 }
 
@@ -178,9 +188,17 @@ func printPatch(p, a string, metadata []jd.Metadata) {
 		out = bNode.Json(metadata...)
 	}
 	if *output == "" {
+		if out == "" {
+			os.Exit(0)
+		}
 		fmt.Print(out)
+		os.Exit(1)
 	} else {
+		if out == "" {
+			os.Exit(0)
+		}
 		ioutil.WriteFile(*output, []byte(out), 0644)
+		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
Similar to unix diff tool returning 0 for no differences and 1 if differences are found. Fixes https://github.com/josephburnett/jd/issues/33

I don't typically write Go code, so if there is a more idiomatic way to do it please let me know.


Using this locally:

```shell
$ ./jd -set ~/code/ocaml/ocaml-gitlab/_build/default/test/cases/commit_statuses/expected.json  ~/code/ocaml/ocaml-gitlab/_build/default/test/cases/commit_statuses/event.json 
@ [["set"],{}]
+ {"allow_failure":false,"author":{"avatar_url":"https://secure.gravatar.com/avatar/67afd2b4c98c9befd18c19f0ee9d94dc?s=80\u0026d=identicon","id":490393,"name":"Tim McGilchrist","state":"active","username":"tmcgilchrist","web_url":"https://gitlab.com/tmcgilchrist"},"coverage":null,"created_at":"2021-10-12T02:37:01.862Z","description":null,"finished_at":"2021-10-12T02:37:01.861Z","id":1670148491,"name":"default","ref":"master","sha":"8d97942a62c9f17dd47e23cf806221230deabaab","started_at":null,"status":"success","target_url":null}
$ echo $?
1
$ ./jd -set ~/code/ocaml/ocaml-gitlab/_build/default/test/cases/commit_statuses/expected.json  ~/code/ocaml/ocaml-gitlab/_build/default/test/cases/commit_statuses/expected.json
$ echo $?
0

```