### PR TITLE
Iss 057

### DIFF
--- a/lib/diff_common.go
+++ b/lib/diff_common.go
@@ -7,7 +7,7 @@ func diff(
 	strategy patchStrategy,
 ) Diff {
 	d := make(Diff, 0)
-	if a.Equals(b) {
+	if a.Equals(b, metadata...) {
 		return d
 	}
 	var de DiffElement

--- a/lib/metadata.go
+++ b/lib/metadata.go
@@ -1,6 +1,7 @@
 package jd
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 )
@@ -18,11 +19,15 @@ type setkeysMetadata struct {
 	keys map[string]bool
 }
 type mergeMetadata struct{}
+type precisionMetadata struct {
+	precision float64
+}
 
-func (setMetadata) is_metadata()      {}
-func (multisetMetadata) is_metadata() {}
-func (setkeysMetadata) is_metadata()  {}
-func (mergeMetadata) is_metadata()    {}
+func (setMetadata) is_metadata()       {}
+func (multisetMetadata) is_metadata()  {}
+func (setkeysMetadata) is_metadata()   {}
+func (mergeMetadata) is_metadata()     {}
+func (precisionMetadata) is_metadata() {}
 
 func (m setMetadata) string() string {
 	return "set"
@@ -48,6 +53,10 @@ func (m mergeMetadata) string() string {
 	return "MERGE"
 }
 
+func (m precisionMetadata) string() string {
+	return "precision=" + fmt.Sprintf("%f", m.precision)
+}
+
 var (
 	// MULTISET interprets all Arrays as Multisets (bags) during Diff
 	// and Equals operations.
@@ -71,6 +80,10 @@ func Setkeys(keys ...string) Metadata {
 	return m
 }
 
+func SetPrecision(precision float64) Metadata {
+	return precisionMetadata{precision}
+}
+
 type patchStrategy string
 
 const (
@@ -83,6 +96,15 @@ func getPatchStrategy(metadata []Metadata) patchStrategy {
 		return mergePatchStrategy
 	}
 	return strictPatchStrategy
+}
+
+func getPrecision(metadata []Metadata) float64 {
+	for _, o := range metadata {
+		if s, ok := o.(precisionMetadata); ok {
+			return s.precision
+		}
+	}
+	return 0
 }
 
 func dispatch(n JsonNode, metadata []Metadata) JsonNode {

--- a/lib/number.go
+++ b/lib/number.go
@@ -3,6 +3,7 @@ package jd
 import (
 	"bytes"
 	"encoding/binary"
+	"math"
 )
 
 type jsonNumber float64
@@ -22,14 +23,14 @@ func (n jsonNumber) raw() interface{} {
 }
 
 func (n1 jsonNumber) Equals(node JsonNode, metadata ...Metadata) bool {
+
+	precision := getPrecision(metadata)
+
 	n2, ok := node.(jsonNumber)
 	if !ok {
 		return false
 	}
-	if n1 != n2 {
-		return false
-	}
-	return true
+	return math.Abs(float64(n1)-float64(n2)) <= precision
 }
 
 func (n jsonNumber) hashCode(metadata []Metadata) [8]byte {

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ var (
 	output        = flag.String("o", "", "Output file")
 	patch         = flag.Bool("p", false, "Patch mode")
 	port          = flag.Int("port", 0, "Serve web UI on port")
+	precision     = flag.Float64("precision", 0, "Precision for numbers")
 	set           = flag.Bool("set", false, "Arrays as sets")
 	setkeys       = flag.String("setkeys", "", "Keys to identify set objects")
 	translate     = flag.String("t", "", "Translate mode")
@@ -140,6 +141,8 @@ func parseMetadata() ([]jd.Metadata, error) {
 	if *format == "merge" {
 		metadata = append(metadata, jd.MERGE)
 	}
+	metadata = append(metadata, jd.SetPrecision(*precision))
+
 	return metadata, nil
 }
 
@@ -154,20 +157,22 @@ func printUsageAndExit() {
 		`When patching (-p) FILE1 is a diff.`,
 		``,
 		`Options:`,
-		`  -color     Print color diff.`,
-		`  -p         Apply patch FILE1 to FILE2 or STDIN.`,
-		`  -o=FILE3   Write to FILE3 instead of STDOUT.`,
-		`  -set       Treat arrays as sets.`,
-		`  -mset      Treat arrays as multisets (bags).`,
-		`  -setkeys   Keys to identify set objects`,
-		`  -yaml      Read and write YAML instead of JSON.`,
-		`  -port=N    Serve web UI on port N`,
-		`  -f=FORMAT  Read and write diff in FORMAT "jd" (default), "patch" (RFC 6902) or`,
-		`             "merge" (RFC 7386)`,
-		`  -t=FORMATS Translate FILE1 between FORMATS. Supported formats are "jd",`,
-		`             "patch" (RFC 6902), "merge" (RFC 7386), "json" and "yaml".`,
-		`             FORMATS are provided as a pair separated by "2". E.g.`,
-		`             "yaml2json" or "jd2patch".`,
+		`  -color       Print color diff.`,
+		`  -p           Apply patch FILE1 to FILE2 or STDIN.`,
+		`  -o=FILE3     Write to FILE3 instead of STDOUT.`,
+		`  -set         Treat arrays as sets.`,
+		`  -mset        Treat arrays as multisets (bags).`,
+		`  -setkeys     Keys to identify set objects`,
+		`  -yaml        Read and write YAML instead of JSON.`,
+		`  -port=N      Serve web UI on port N`,
+		`  -precision=N Precision for numbers. Positive number for decimal places or`,
+		`               negative for significant figures.`,
+		`  -f=FORMAT    Read and write diff in FORMAT "jd" (default), "patch" (RFC 6902) or`,
+		`               "merge" (RFC 7386)`,
+		`  -t=FORMATS   Translate FILE1 between FORMATS. Supported formats are "jd",`,
+		`               "patch" (RFC 6902), "merge" (RFC 7386), "json" and "yaml".`,
+		`               FORMATS are provided as a pair separated by "2". E.g.`,
+		`               "yaml2json" or "jd2patch".`,
 		``,
 		`Examples:`,
 		`  jd a.json b.json`,


### PR DESCRIPTION
@josephburnett 

I had the same need to include a parameter for precision. I have updated the code to support this feature.

Some notes:

* I noticed one bug (I think) in `diff_common.go` where metadata was not being passed through.
* Precision is passed as a float64 flag which appears to provide the most flexibility in precision
* I have updated the code (against v 1.7) and marked as version 1.8.

Please reach out if you would like me to make any changes or need clarification.

Thanks for the amazing utility.