### PR TITLE
Add character-level diff for strings.

### DIFF
--- a/v2/diff_write_test.go
+++ b/v2/diff_write_test.go
@@ -1,6 +1,7 @@
 package jd
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -23,6 +24,48 @@ func TestDiffRender(t *testing.T) {
 		`- {"b":1}`,
 		`@ ["c"]`,
 		`+ {"b":1}`)
+	// String changes
+	checkDiffRender(t, `{"a":"bar"}`, `{"a":"baz"}`,
+		`@ ["a"]`,
+		`- "bar"`,
+		`+ "baz"`)
+	// Array of strings
+	checkDiffRender(t, `{"qux":["foobar","foobaz"]}`, `{"qux":["fooarrr","foobaz"]}`,
+		`@ ["qux",0]`,
+		`[`,
+		`- "foobar"`,
+		`+ "fooarrr"`,
+		`  "foobaz"`,
+	)
+	// Addition only
+	checkDiffRender(t, `{"str":""}`, `{"str":"abc"}`,
+		`@ ["str"]`,
+		`- ""`,
+		`+ "abc"`)
+	// Removal only
+	checkDiffRender(t, `{"str":"abc"}`, `{"str":""}`,
+		`@ ["str"]`,
+		`- "abc"`,
+		`+ ""`)
+	// Nested strings
+	checkDiffRender(t, `{"a":{"b":"hello"}}`, `{"a":{"b":"world"}}`,
+		`@ ["a","b"]`,
+		`- "hello"`,
+		`+ "world"`)
+	// Multiple string changes
+	checkDiffRender(t, `{"a":"foo","b":"bar"}`, `{"a":"baz","b":"qux"}`,
+		`@ ["a"]`,
+		`- "foo"`,
+		`+ "baz"`,
+		`@ ["b"]`,
+		`- "bar"`,
+		`+ "qux"`)
+	// Key change
+	checkDiffRender(t, `{"a":"foo"}`, `{"b":"foo"}`,
+		`@ ["a"]`,
+		`- "foo"`,
+		`@ ["b"]`,
+		`+ "foo"`)
 }
 
 func checkDiffRender(t *testing.T, a, b string, diffLines ...string) {
@@ -38,10 +81,85 @@ func checkDiffRender(t *testing.T, a, b string, diffLines ...string) {
 	if err != nil {
 		t.Errorf("%v", err.Error())
 	}
+
+	// Test without color
 	d := aJson.diff(bJson, nil, []Option{}, strictPatchStrategy).Render()
 	if d != diff {
 		t.Errorf("%v.diff(%v) = %v. Want %v.", a, b, d, diff)
 	}
+
+	// Test with color
+	coloredDiff := aJson.diff(bJson, nil, []Option{}, strictPatchStrategy).Render(COLOR)
+	strippedDiff := stripAnsiCodes(coloredDiff)
+	if strippedDiff != diff {
+		t.Errorf("%v.diff(%v) with color (stripped) = %v. Want %v.", a, b, strippedDiff, diff)
+	}
+
+	// Verify that uncolored parts in string diffs match between + and - lines
+	lines := strings.Split(coloredDiff, "\n")
+	var minusLine, plusLine string
+	for i, line := range lines {
+		if len(line) == 0 {
+			continue
+		}
+		if line[0] == '-' && strings.Contains(line, "\"") { // Only check string diffs
+			minusLine = line
+			if i+1 < len(lines) && len(lines[i+1]) > 0 && lines[i+1][0] == '+' {
+				plusLine = lines[i+1]
+				minusUncolored := removeColoredParts(minusLine[1:]) // Skip the "- " prefix
+				plusUncolored := removeColoredParts(plusLine[1:])   // Skip the "+ " prefix
+				if minusUncolored != plusUncolored {
+					t.Errorf("Uncolored parts don't match:\n- %s\n+ %s", minusUncolored, plusUncolored)
+				}
+			}
+		}
+	}
+}
+
+// removeColoredParts returns the string with the colored parts (including the text between color codes) removed
+func removeColoredParts(s string) string {
+	result := ""
+	inColor := false
+	for i := 0; i < len(s); i++ {
+		// detect a color code (starts coloring)
+		if !inColor && i+1 < len(s) && s[i] == '\033' && s[i+1] == '[' {
+			inColor = true
+			i++ // skip '['
+			continue
+		}
+		// if not colored, add the character to the result
+		if !inColor {
+			result += string(s[i])
+		}
+		// detect the reset color code (ends coloring)
+		if inColor && i+1 < len(s) && s[i] == '[' && s[i+1] == '0' && i+2 < len(s) && s[i+2] == 'm' {
+			inColor = false
+			i += 2
+		}
+	}
+	return result
+}
+
+// stripAnsiCodes removes ANSI color escape sequences from a string
+func stripAnsiCodes(s string) string {
+	result := ""
+	inEscape := false
+
+	for i := 0; i < len(s); i++ {
+		if !inEscape && i+1 < len(s) && s[i] == '\033' && s[i+1] == '[' {
+			inEscape = true
+			i++ // skip the '['
+			continue
+		}
+		if inEscape {
+			if s[i] == 'm' {
+				inEscape = false
+			}
+			continue
+		}
+		result += string(s[i])
+	}
+	return result
 }
 
 func TestDiffRenderPatch(t *testing.T) {


### PR DESCRIPTION
Implements #91.

@josephburnett this is my first attempt at getting character-level diff to work, and by no means a complete PR. 

Can you take a look and see if this goes in the right direction?

What this PR does:
``` diff
+ Implement a character-level diff for strings
```

What this PR does not do (yet):
``` diff
- nicely structure code
- add tests
- add a command-line option
- implement a more optimal diff algorithm (Myers diff for maximizing the common sequence overlap.)
```

## Example:

`a.json`:
   ```
   {
    "foo": "bar",
    "baz": 1,
    "qux": ["foobar", "foobaz"]
   }
   ```
`b.json`:
```
{
    "foo": "bazzz",
    "baz": 2,
    "qux": ["foarrr", "foobaz"]
}
```

`jd -v2 a.json b.json`:
<img src="https://github.com/user-attachments/assets/7ba90c01-12fa-4e36-8f10-91168df412a8" width="96">

   