### PR TITLE
Build artifacts for riscv64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ build-all : test pack-web validate-toolchain
 	cd v2/jd ; GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -tags include_web -o ../../release/jd-arm64-linux main.go
 	cd v2/jd ; GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -tags include_web -o ../../release/jd-arm64-darwin main.go
 	cd v2/jd ; GOOS=windows GOARCH=arm64 CGO_ENABLED=0 go build -tags include_web -o ../../release/jd-arm64-windows.exe main.go
+	cd v2/jd ; GOOS=linux GOARCH=riscv64 CGO_ENABLED=0 go build -tags include_web -o ../../release/jd-riscv64-linux main.go
 
 .PHONY : build-docker
 build-docker : check-env test


### PR DESCRIPTION
hi there.

Recently, riscv64 has gained widespread adoption, and we might consider adding riscv64 support to `jd`. Go has excellent support for riscv64, so we only need minor modifications to enable building artifacts for riscv64.

I ran `make build` on an riscv64 server, and the results show everything went smoothly.

See details here, [build.log](https://github.com/user-attachments/files/23582343/build.log)


I noticed that I should run `make fuzz`, but found that the results don't seem quite ideal. I also ran it on my x86 machine, but encountered errors as well. However, the x86 run in CI didn't report any errors, which is somewhat puzzling to me.

See specific logs below

| name      | URL |
| ----------- | ----------- |
| x86-local  | [x86.log](https://github.com/user-attachments/files/23582524/x86.log) |
| riscv64-local | [riscv64.log](https://github.com/user-attachments/files/23582527/riscv64.log) |
| x86-ci   | [CI](https://github.com/ffgan/jd/actions/runs/19422592473/job/55562741128) |

Nevertheless, I believe this should be unrelated to riscv64 and should also be unrelated to this PR, so I've deliberately ignored handling this error here.

So, if you have any questions about the above content, feel free to @ me directly anytime. I'm happy to answer all questions.

---
Other Info
Co-authored by: nijincheng@iscas.ac.cn;