### PR TITLE
Replace deprecated ioutil with os and io

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"math/rand"
 	"os"
@@ -133,7 +133,6 @@ const (
 	translateMode mode = "trans"
 )
 
-
 func parseMetadata() ([]jd.Metadata, error) {
 	if *precision != 0.0 && (*set || *mset) {
 		return nil, fmt.Errorf("-precision cannot be used with -set or -mset because they use hashcodes")
@@ -246,7 +245,7 @@ func printDiff(a, b string, metadata []jd.Metadata) {
 	if *output == "" {
 		fmt.Print(str)
 	} else {
-		ioutil.WriteFile(*output, []byte(str), 0644)
+		os.WriteFile(*output, []byte(str), 0644)
 	}
 	if haveDiff {
 		os.Exit(1)
@@ -262,7 +261,7 @@ func printDiffV2(a, b string, options []v2.Option) {
 	if *output == "" {
 		fmt.Print(str)
 	} else {
-		ioutil.WriteFile(*output, []byte(str), 0644)
+		os.WriteFile(*output, []byte(str), 0644)
 	}
 	if haveDiff {
 		os.Exit(1)
@@ -435,7 +434,7 @@ func printPatch(p, a string, metadata []jd.Metadata) {
 	if *output == "" {
 		fmt.Print(out)
 	} else {
-		ioutil.WriteFile(*output, []byte(out), 0644)
+		os.WriteFile(*output, []byte(out), 0644)
 	}
 	os.Exit(0)
 }
@@ -478,7 +477,7 @@ func printPatchV2(p, a string, options []v2.Option) {
 	if *output == "" {
 		fmt.Print(out)
 	} else {
-		ioutil.WriteFile(*output, []byte(out), 0644)
+		os.WriteFile(*output, []byte(out), 0644)
 	}
 	os.Exit(0)
 }
@@ -534,7 +533,7 @@ func printTranslation(a string) {
 	if *output == "" {
 		fmt.Print(out)
 	} else {
-		ioutil.WriteFile(*output, []byte(out), 0644)
+		os.WriteFile(*output, []byte(out), 0644)
 	}
 	os.Exit(0)
 }
@@ -590,7 +589,7 @@ func printTranslationV2(a string) {
 	if *output == "" {
 		fmt.Print(out)
 	} else {
-		ioutil.WriteFile(*output, []byte(out), 0644)
+		os.WriteFile(*output, []byte(out), 0644)
 	}
 	os.Exit(0)
 }
@@ -605,7 +604,7 @@ func errorfAndExit(msg string, args ...interface{}) {
 }
 
 func readFile(filename string) string {
-	bytes, err := ioutil.ReadFile(filename)
+	bytes, err := os.ReadFile(filename)
 	if err != nil {
 		log.Print(err.Error())
 		os.Exit(2)
@@ -615,7 +614,7 @@ func readFile(filename string) string {
 
 func readStdin() string {
 	r := bufio.NewReader(os.Stdin)
-	bytes, err := ioutil.ReadAll(r)
+	bytes, err := io.ReadAll(r)
 	if err != nil {
 		log.Print(err.Error())
 		os.Exit(2)

--- a/v2/diff_read.go
+++ b/v2/diff_read.go
@@ -3,13 +3,13 @@ package jd
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 )
 
 // ReadDiffFile reads a file in native jd format.
 func ReadDiffFile(filename string) (Diff, error) {
-	bytes, err := ioutil.ReadFile(filename)
+	bytes, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
@@ -240,7 +240,7 @@ func errorfAt(lineZeroIndex int, err string, i ...interface{}) (Diff, error) {
 // ReadPatchFile reads a JSON Patch (RFC 6902) from a file. It is subject
 // to the same restrictions as ReadPatchString.
 func ReadPatchFile(filename string) (Diff, error) {
-	bytes, err := ioutil.ReadFile(filename)
+	bytes, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
@@ -485,7 +485,7 @@ func readPatchDiffElement(patch []patchElement) (DiffElement, []patchElement, er
 
 // ReadMergeFile reads a JSON Merge Patch (RFC 7386) from a file.
 func ReadMergeFile(filename string) (Diff, error) {
-	bytes, err := ioutil.ReadFile(filename)
+	bytes, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/v2/internal/web/pack/main.go
+++ b/v2/internal/web/pack/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 var files = []string{
@@ -19,7 +19,7 @@ func main() {
 	pack += "\n"
 	pack += "var base64EncodedFiles = map[string]string{\n"
 	for _, f := range files {
-		b, err := ioutil.ReadFile(fmt.Sprintf("internal/web/assets/%v", f))
+		b, err := os.ReadFile(fmt.Sprintf("internal/web/assets/%v", f))
 		if err != nil {
 			panic(err)
 		}
@@ -27,7 +27,7 @@ func main() {
 		pack += fmt.Sprintf("\t%q: %q,\n", f, s)
 	}
 	pack += "}"
-	err := ioutil.WriteFile("internal/web/serve/files.go", []byte(pack), 0644)
+	err := os.WriteFile("internal/web/serve/files.go", []byte(pack), 0644)
 	if err != nil {
 		panic(err)
 	}

--- a/v2/jd/main.go
+++ b/v2/jd/main.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"math/rand"
 	"net/http"
@@ -239,7 +239,7 @@ func printDiff(a, b string, options []jd.Option) {
 	if *output == "" {
 		fmt.Print(str)
 	} else {
-		ioutil.WriteFile(*output, []byte(str), 0644)
+		os.WriteFile(*output, []byte(str), 0644)
 	}
 	if haveDiff {
 		os.Exit(1)
@@ -414,7 +414,7 @@ func printTranslation(a string) {
 	if *output == "" {
 		fmt.Print(out)
 	} else {
-		ioutil.WriteFile(*output, []byte(out), 0644)
+		os.WriteFile(*output, []byte(out), 0644)
 	}
 	os.Exit(0)
 }
@@ -429,7 +429,7 @@ func errorfAndExit(msg string, args ...interface{}) {
 }
 
 func readFile(filename string) string {
-	bytes, err := ioutil.ReadFile(filename)
+	bytes, err := os.ReadFile(filename)
 	if err != nil {
 		log.Print(err.Error())
 		os.Exit(2)
@@ -439,7 +439,7 @@ func readFile(filename string) string {
 
 func readStdin() string {
 	r := bufio.NewReader(os.Stdin)
-	bytes, err := ioutil.ReadAll(r)
+	bytes, err := io.ReadAll(r)
 	if err != nil {
 		log.Print(err.Error())
 		os.Exit(2)

--- a/v2/node_read.go
+++ b/v2/node_read.go
@@ -2,7 +2,7 @@ package jd
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -10,7 +10,7 @@ import (
 
 // ReadJsonFile reads a file as JSON and constructs a JsonNode.
 func ReadJsonFile(filename string) (JsonNode, error) {
-	bytes, err := ioutil.ReadFile(filename)
+	bytes, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
@@ -19,7 +19,7 @@ func ReadJsonFile(filename string) (JsonNode, error) {
 
 // ReadYamlFile reads a file as YAML and constructs a JsonNode.
 func ReadYamlFile(filename string) (JsonNode, error) {
-	bytes, err := ioutil.ReadFile(filename)
+	bytes, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR replaces function usages from `io/ioutil` with the same functions from `io` and `os`.

Only `v2` is affected.

## Motivation

[io/ioutil](https://pkg.go.dev/io/ioutil) is deprecated:

> Deprecated: As of Go 1.16, the same functionality is now provided by package [io](https://pkg.go.dev/io) or package [os](https://pkg.go.dev/os), and those implementations should be preferred in new code. See the specific function documentation for details.