### PR TITLE
Fix Myers diff backtracking off-by-one (#112)

### DIFF
--- a/v2/list.go
+++ b/v2/list.go
@@ -1030,7 +1030,7 @@ func buildMyersEdits(a, b jsonList, trace [][]int, opts *options) []myersEdit {
 
 	// Backtrack through the trace
 	for D := len(trace) - 1; D > 0; D-- {
-		prevV := trace[D-1]
+		prevV := trace[D]
 
 		k := x - y
 

--- a/v2/regression_test.go
+++ b/v2/regression_test.go
@@ -38,6 +38,22 @@ spec:
 	}
 }
 
+func TestIssue112(t *testing.T) {
+	// https://github.com/josephburnett/jd/issues/112
+	// Arrays with more than 10 elements triggered the Myers diff
+	// algorithm which had an off-by-one in its backtracking logic.
+	ctx := newTestContext(t)
+	checkDiff(ctx,
+		`{"key1":["v01","v02","v03","v04","v05","v06","v07","v08","v09","v10","v11"]}`,
+		`{"key1":["v01","v02","v03","v04","v05","v06","v07","v08","v09","v10","v11 "]}`,
+		`@ ["key1",10]`,
+		`  "v10"`,
+		`- "v11"`,
+		`+ "v11 "`,
+		`]`,
+	)
+}
+
 func TestDebug(t *testing.T) {
 	fuzz(t, `0`, ``, 0)
 }


### PR DESCRIPTION
Fixes #112.

`buildMyersEdits` uses `trace[D-1]` for backtracking, but the trace is saved before each forward iteration updates V. So `trace[D]` holds the V state after D-1 steps, not `trace[D-1]`. Wrong lookup produces garbled edit sequences for arrays with more than 10 elements.

Fix: `trace[D-1]` -> `trace[D]` (v2/list.go:1033).

Includes a regression test reproducing the exact scenario from #112.