### PR TITLE
Adds support for string based numbers

### DIFF
--- a/v2/node.go
+++ b/v2/node.go
@@ -110,11 +110,7 @@ func NewJsonNode(n interface{}) (JsonNode, error) {
 	case jsonArray:
 		return t, nil
 	case json.Number:
-		f, err := t.Float64()
-		if err != nil {
-			return nil, err
-		}
-		return jsonNumber(f), nil
+		return jsonStringNumber(t), nil
 	case float64:
 		return jsonNumber(t), nil
 	case int:

--- a/v2/node.go
+++ b/v2/node.go
@@ -133,6 +133,8 @@ func NewJsonNode(n interface{}) (JsonNode, error) {
 		return jsonNull(nil), nil
 	case jsonNull:
 		return t, nil
+	case JsonNode:
+		return t, nil
 	default:
 		return nil, fmt.Errorf("unsupported type %T", t)
 	}

--- a/v2/number.go
+++ b/v2/number.go
@@ -34,11 +34,16 @@ func (n1 jsonNumber) equals(node JsonNode, o *options) bool {
 	}
 
 	n2, ok := node.(jsonNumber)
-	if !ok {
-		return false
+	if ok {
+		return math.Abs(float64(n1)-float64(n2)) <= precision
 	}
 
-	return math.Abs(float64(n1)-float64(n2)) <= precision
+	sn2, ok := node.(jsonStringNumber)
+	if ok {
+		return sn2.equals(n1, o)
+	}
+
+	return false
 }
 
 func (n jsonNumber) hashCode(opts *options) [8]byte {

--- a/v2/string_number.go
+++ b/v2/string_number.go
@@ -2,7 +2,7 @@ package jd
 
 type jsonStringNumber string
 
-var _ JsonNode = jsonStringNumber("")
+var _ JsonNode = jsonStringNumber("0")
 
 func (s jsonStringNumber) Json(_ ...Option) string {
 	return string(s)
@@ -22,11 +22,15 @@ func (s1 jsonStringNumber) Equals(n JsonNode, opts ...Option) bool {
 }
 
 func (s1 jsonStringNumber) equals(n JsonNode, o *options) bool {
-	s2, ok := n.(jsonStringNumber)
-	if !ok {
+	switch t := n.(type) {
+	case jsonStringNumber:
+		return s1 == t
+	case jsonNumber:
+		s2 := t.Json(nil)
+		return string(s1) == s2
+	default:
 		return false
 	}
-	return s1 == s2
 }
 
 func (s jsonStringNumber) hashCode(_ *options) [8]byte {

--- a/v2/string_number.go
+++ b/v2/string_number.go
@@ -1,0 +1,63 @@
+package jd
+
+type jsonStringNumber string
+
+var _ JsonNode = jsonStringNumber("")
+
+func (s jsonStringNumber) Json(_ ...Option) string {
+	return string(s)
+}
+
+func (s jsonStringNumber) Yaml(_ ...Option) string {
+	return string(s)
+}
+
+func (s jsonStringNumber) raw() interface{} {
+	return string(s)
+}
+
+func (s1 jsonStringNumber) Equals(n JsonNode, opts ...Option) bool {
+	o := refine(&options{retain: opts}, nil)
+	return s1.equals(n, o)
+}
+
+func (s1 jsonStringNumber) equals(n JsonNode, o *options) bool {
+	s2, ok := n.(jsonStringNumber)
+	if !ok {
+		return false
+	}
+	return s1 == s2
+}
+
+func (s jsonStringNumber) hashCode(_ *options) [8]byte {
+	return hash([]byte(s))
+}
+
+func (s jsonStringNumber) Diff(n JsonNode, opts ...Option) Diff {
+	o := refine(newOptions(opts), nil)
+	return s.diff(n, make(Path, 0), o, getPatchStrategy(o))
+}
+
+func (s1 jsonStringNumber) diff(
+	n JsonNode,
+	path Path,
+	opts *options,
+	strategy patchStrategy,
+) Diff {
+	// Use event-driven diff architecture
+	events := generateSimpleEvents(s1, n, opts)
+	processor := newSimpleDiffProcessor(path, opts, strategy)
+	return processor.ProcessEvents(events)
+}
+
+func (s jsonStringNumber) Patch(d Diff) (JsonNode, error) {
+	return patchAll(s, d)
+}
+
+func (s jsonStringNumber) patch(
+	pathBehind, pathAhead Path,
+	before, oldValues, newValues, after []JsonNode,
+	strategy patchStrategy,
+) (JsonNode, error) {
+	return patch(s, pathBehind, pathAhead, before, oldValues, newValues, after, strategy)
+}


### PR DESCRIPTION
It is AI slop to convert `json.Number` to `float64`.

If it were possible to store a JSON number as `float64`, the type `json.Number` would not be needed in `encoding/json`.

This pull request adds a type `jsonStringNumber` based on `jsonString` and implements the `equal` methods to compare `jsonStringNumber` and `jsonNumber`.
